### PR TITLE
feat/add-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [ 1.0.x ]
+  pull_request:
+    branches: [ 1.0.x ]
+  workflow_dispatch:
+
+jobs:
+  islandora-module-ci:
+    uses: digitalutsc/reusable_workflows/.github/workflows/islandora-module-ci.yml@main
+    with:
+      module_name: json_field_processor
+      install_chromedriver: true


### PR DESCRIPTION
# Description
This PR adds a new reusable workflow (called by `ci.yml`).

# Changes
- Adds `ci.yml` that makes a call to the `islandora-module-ci` reusable workflow from `digitalutsc/reusable_workflows`, passing in the module name and enabling Chromedriver installation.