### PR TITLE
refactor: implement dependency injection, and minor fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ 1.0.x ]
+    branches: [ 1.x ]
   pull_request:
-    branches: [ 1.0.x ]
+    branches: [ 1.x ]
   workflow_dispatch:
 
 jobs:

--- a/src/Form/JSONFieldProcessorConfigFormBase.php
+++ b/src/Form/JSONFieldProcessorConfigFormBase.php
@@ -1,13 +1,13 @@
 <?php
 
-// phpcs:disable -- DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
-
 namespace Drupal\json_field_processor\Form;
 
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -31,13 +31,37 @@ class JSONFieldProcessorConfigFormBase extends EntityForm {
   protected $entityStorage;
 
   /**
+   * The bundle info services.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $bundleInfo;
+
+  /**
+   * The field manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $fieldManager;
+
+  /**
    * Construct the JSONFieldProcessorConfigFormBase.
    *
    * @param \Drupal\Core\Entity\EntityStorageInterface $entity_storage
    *   An entity query factory for the json_field_processor_config entity type.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $bundle_info
+   *   The bundle info services.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $field_manager
+   *   The field manager service.
    */
-  public function __construct(EntityStorageInterface $entity_storage) {
+  public function __construct(
+    EntityStorageInterface $entity_storage,
+    EntityTypeBundleInfoInterface $bundle_info,
+    EntityFieldManagerInterface $field_manager,
+  ) {
     $this->entityStorage = $entity_storage;
+    $this->bundleInfo = $bundle_info;
+    $this->fieldManager = $field_manager;
   }
 
   /**
@@ -50,7 +74,11 @@ class JSONFieldProcessorConfigFormBase extends EntityForm {
    *   The form object.
    */
   public static function create(ContainerInterface $container) {
-    $form = new static($container->get('entity_type.manager')->getStorage('json_field_processor_config'));
+    $form = new static(
+      $container->get('entity_type.manager')->getStorage('json_field_processor_config'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity_field.manager')
+    );
     $form->setMessenger($container->get('messenger'));
     return $form;
   }
@@ -184,17 +212,17 @@ class JSONFieldProcessorConfigFormBase extends EntityForm {
     $entered_name = $form_state->getValue('label');
 
     // Load field definitions for both 'node' and 'media' entity types.
-    $node_bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo('node');
-    $media_bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
+    $node_bundles = $this->bundleInfo->getBundleInfo('node');
+    $media_bundles = $this->bundleInfo->getBundleInfo('media');
 
     $node_fields = [];
     foreach (array_keys($node_bundles) as $bundle) {
-      $node_fields += \Drupal::service('entity_field.manager')->getFieldDefinitions('node', $bundle);
+      $node_fields += $this->fieldManager->getFieldDefinitions('node', $bundle);
     }
 
     $media_fields = [];
     foreach (array_keys($media_bundles) as $bundle) {
-      $media_fields += \Drupal::service('entity_field.manager')->getFieldDefinitions('media', $bundle);
+      $media_fields += $this->fieldManager->getFieldDefinitions('media', $bundle);
     }
 
     // Check if the field with the given machine name exists.

--- a/src/Plugin/search_api/processor/JSONFieldProcessor.php
+++ b/src/Plugin/search_api/processor/JSONFieldProcessor.php
@@ -1,8 +1,5 @@
 <?php
 
-// phpcs:disable -- Drupal.NamingConventions.ValidVariableName.LowerCamelName
-// phpcs:disable -- Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
-
 namespace Drupal\json_field_processor\Plugin\search_api\processor;
 
 use Drupal\search_api\Datasource\DatasourceInterface;
@@ -49,21 +46,21 @@ class JSONFieldProcessor extends ProcessorPluginBase {
    *
    * @var array<string, string>
    */
-  protected $json_field_configurations = [];
+  protected $jsonFieldConfigurations = [];
 
   /**
    * An associative array mapping names to labels.
    *
    * @var array<string, string>
    */
-  protected $json_field_name = [];
+  protected $jsonFieldName = [];
 
   /**
    * Load the relationship types from the database.
    *
-   * Populates $json_field_configurations with field_name => json_path pairs.
+   * Populates $jsonFieldConfigurations with field_name => json_path pairs.
    */
-  protected function loadJSONFieldConfigurations() {
+  protected function loadJsonFieldConfigurations() {
     // Fetch the results from the database.
     $json_field_processor_config = \Drupal::entityTypeManager()->getStorage('json_field_processor_config')->loadMultiple();
     foreach ($json_field_processor_config as $submission) {
@@ -71,8 +68,8 @@ class JSONFieldProcessor extends ProcessorPluginBase {
       $field_name = $submission->id();
       $json_path = $submission->json_path;
       // Process each submission as needed.
-      $this->json_field_configurations[$field_name] = $json_path;
-      $this->json_field_name[$field_name] = $label;
+      $this->jsonFieldConfigurations[$field_name] = $json_path;
+      $this->jsonFieldName[$field_name] = $label;
     }
   }
 
@@ -94,10 +91,10 @@ class JSONFieldProcessor extends ProcessorPluginBase {
    */
   public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     $properties = [];
-    $this->loadJSONFieldConfigurations();
+    $this->loadJsonFieldConfigurations();
 
     if (!$datasource) {
-      foreach ($this->json_field_configurations as $field_name => $json_path) {
+      foreach ($this->jsonFieldConfigurations as $field_name => $json_path) {
         $definition = [
           'label' => $this->t('Field: @label', ['@label' => $json_path]),
           'description' => $this->t('Json Data of Islandora Site to be indexed to Solr'),
@@ -121,7 +118,7 @@ class JSONFieldProcessor extends ProcessorPluginBase {
 
     // Process JSON fields for supported entity types.
     if (in_array($datasourceId, ['entity:node', 'entity:media'])) {
-      foreach ($this->json_field_configurations as $field_name => $json_path) {
+      foreach ($this->jsonFieldConfigurations as $field_name => $json_path) {
         $this->processJsonField($entity, $item, $field_name, $json_path);
       }
     }
@@ -140,7 +137,7 @@ class JSONFieldProcessor extends ProcessorPluginBase {
    *   The JSON path to process.
    */
   private function processJsonField($entity, ItemInterface $item, $field_name, $json_path) {
-    $json_field = $this->json_field_name[$field_name];
+    $json_field = $this->jsonFieldName[$field_name];
 
     if ($entity->hasField($json_field)) {
       $json_data = $entity->get($json_field)->value;

--- a/tests/src/Functional/JSONFieldProcessorConfigEntityTest.php
+++ b/tests/src/Functional/JSONFieldProcessorConfigEntityTest.php
@@ -185,16 +185,17 @@ class JSONFieldProcessorConfigEntityTest extends BrowserTestBase {
       );
     $this->assertEquals(count($cancel_button), 1, 'Found cancel button linking to list page.');
 
-    // phpcs:disable -- Drupal.Commenting.InlineComment.SpacingBefore
     // Step 9: Reserved keyword test.
     // $this->drupalGet(Url::fromRoute('entity.json_field_processor_config.add_form'));
     // $this->submitForm([
-    //     'field_name' => 'Custom Field Name',
-    //     'id' => 'custom',
-    //     'json_path' => 'data.custom',
-    //     'label' => 'Custom',
+    // 'field_name' => 'Custom Field Name',
+    // 'id' => 'custom',
+    // 'json_path' => 'data.custom',
+    // 'label' => 'Custom',
     // ], 'Create JSON Field Processor Configuration');
-    // $assert->pageTextContains('Additionally, it cannot be the reserved word "custom".');.
+    // $assert->pageTextContains(
+    // 'Additionally, it cannot be the reserved word "custom".'
+    // );.
   }
 
 }


### PR DESCRIPTION
# Description
This PR refactors the codebase by implementing dependency injection for services that previously made direct `\Drupal` service calls, and remove the phpcs error ignore comments by implementing their logic, to follow latest Drupal coding standards.

# Changes
- **Dependency Injection**: The `JSONFieldProcessorConfigFormBase` class now injects the `bundleInfo` and `fieldManager` services through constructor and create method, which replaces direct `\Drupal` service calls.
- Change method and variable names in the `JSONFieldProcessor` plugin to use camel case.